### PR TITLE
More agressive anonymous APEX query escape

### DIFF
--- a/tooling.go
+++ b/tooling.go
@@ -33,7 +33,7 @@ func (client *Client) ExecuteAnonymous(apexBody string) (*ExecuteAnonymousResult
 	// Create the endpoint
 	formatString := "%s/services/data/v%s/tooling/executeAnonymous/?anonymousBody=%s"
 	baseURL := client.instanceURL
-	endpoint := fmt.Sprintf(formatString, baseURL, client.apiVersion, url.PathEscape(apexBody))
+	endpoint := fmt.Sprintf(formatString, baseURL, client.apiVersion, url.QueryEscape(apexBody))
 
 	data, err := client.httpRequest("GET", endpoint, nil)
 	if err != nil {


### PR DESCRIPTION
Change to `QueryEscape` to escape some super special characters like & and + (https://play.golang.org/p/KdJEv7HNE1i)