### PR TITLE
Fix Issue #9: skip protected fields during record update.

### DIFF
--- a/sobject.go
+++ b/sobject.go
@@ -14,6 +14,28 @@ const (
 	sobjectIDKey         = "Id"
 )
 
+var (
+	// When updating existing records, certain fields are read only and needs to be removed before submitted to Salesforce.
+	// Following list of fields are extracted from INVALID_FIELD_FOR_INSERT_UPDATE error message.
+	blacklistedUpdateFields = []string{
+		"LastModifiedDate",
+		"LastReferencedDate",
+		"IsClosed",
+		"ContactPhone",
+		"CreatedById",
+		"CaseNumber",
+		"ContactFax",
+		"ContactMobile",
+		"IsDeleted",
+		"LastViewedDate",
+		"SystemModstamp",
+		"CreatedDate",
+		"ContactEmail",
+		"ClosedDate",
+		"LastModifiedById",
+	}
+)
+
 // SObject describes an instance of SObject.
 // Ref: https://developer.salesforce.com/docs/atlas.en-us.214.0.api_rest.meta/api_rest/resources_sobject_basic_info.htm
 type SObject map[string]interface{}
@@ -346,6 +368,9 @@ func (obj *SObject) makeCopy() map[string]interface{} {
 			continue
 		}
 		stripped[key] = val
+	}
+	for _, key := range blacklistedUpdateFields {
+		delete(stripped, key)
 	}
 	return stripped
 }

--- a/sobject_test.go
+++ b/sobject_test.go
@@ -217,3 +217,32 @@ func TestSObject_Delete(t *testing.T) {
 		t.Fail()
 	}
 }
+
+// TestSObject_GetUpdate validates updating of existing records.
+func TestSObject_GetUpdate(t *testing.T) {
+	client := requireClient(t, true)
+
+	// Create a new case first.
+	case1 := client.SObject("Case").
+		Set("Subject", "Original").
+		Create().
+		Get()
+
+	// Query the case by ID, then update the Subject.
+	case2 := client.SObject("Case").
+		Get(case1.ID()).
+		Set("Subject", "Updated").
+		Update().
+		Get()
+
+	// Query the case by ID again and check if the Subject has been updated.
+	case3 := client.SObject("Case").
+		Get(case2.ID())
+
+	if case3.StringField("Subject") != "Updated" {
+		t.Fail()
+	}
+
+	user1 := client.SObject("User").Create()
+	log.Println(user1.ID())
+}


### PR DESCRIPTION
This change skips some protected fields when updating an existing record
to avoid an INVALID_FIELD_FOR_INSERT_UPDATE.