### PR TITLE
Added logging & sid/loc support 

### DIFF
--- a/errorHelpers.go
+++ b/errorHelpers.go
@@ -1,0 +1,52 @@
+package simpleforce
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"github.com/pkg/errors"
+	"log"
+)
+
+var (
+	// ErrFailure is a generic error if none of the other errors are appropriate.
+	ErrFailure = errors.New("general failure")
+
+	// ErrAuthentication is returned when authentication failed.
+	ErrAuthentication = errors.New("authentication failure")
+)
+
+type jsonError []struct {
+	Message   string `json:"message"`
+	ErrorCode string `json:"errorCode"`
+}
+
+type xmlError struct {
+	Message string `xml:"Body>Fault>faultstring"`
+	ErrorCode string `xml:"Body>Fault>faultcode"`
+}
+
+//Need to get information out of this package.
+func ParseSalesforceError(statusCode int, responseBody []byte) (err error) {
+	jsonError := jsonError{}
+	xmlError := xmlError{}
+	err = json.Unmarshal(responseBody, &jsonError)
+	if err != nil {
+		//Unable to parse json. Try xml
+		err = xml.Unmarshal(responseBody, &xmlError)
+		if err != nil {
+			//Unable to parse json or XML
+			log.Println("ERROR UNMARSHALLING: ", err)
+			return ErrFailure
+		}
+		//successfully parsed XML:
+		message := fmt.Sprintf(logPrefix+" Error. http code: %v Error Message:  %v Error Code: %v", statusCode, xmlError.Message, xmlError.ErrorCode)
+		err = errors.New(message)
+		return err
+	} else {
+		//Successfully parsed json error:
+		message := fmt.Sprintf(logPrefix+" Error. http code: %v Error Message:  %v Error Code: %v", statusCode, jsonError[0].Message, jsonError[0].ErrorCode)
+		err = errors.New(message)
+		return err
+	}
+}

--- a/force.go
+++ b/force.go
@@ -111,11 +111,6 @@ func (client *Client) isLoggedIn() bool {
 	return client.sessionID != ""
 }
 
-func (client *Client) LoginSidLoc(sid string, loc string) {
-	client.sessionID = sid
-	client.instanceURL = loc
-}
-
 // LoginPassword signs into salesforce using password. token is optional if trusted IP is configured.
 // Ref: https://developer.salesforce.com/docs/atlas.en-us.214.0.api_rest.meta/api_rest/intro_understanding_username_password_oauth_flow.htm
 // Ref: https://developer.salesforce.com/docs/atlas.en-us.214.0.api.meta/api/sforce_api_calls_login.htm

--- a/force.go
+++ b/force.go
@@ -219,7 +219,7 @@ func (client *Client) httpRequest(method, url string, body io.Reader) ([]byte, e
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		log.Println(logPrefix, "status:", resp.StatusCode)
-		log.Println(ioutil.ReadAll(resp.Body))
+		log.Println(resp.Body)
 		return nil, ErrFailure
 	}
 

--- a/force.go
+++ b/force.go
@@ -219,7 +219,7 @@ func (client *Client) httpRequest(method, url string, body io.Reader) ([]byte, e
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		log.Println(logPrefix, "status:", resp.StatusCode)
-		log.Println(resp.Body)
+		log.Println(string(ioutil.ReadAll(resp.Body)))
 		return nil, ErrFailure
 	}
 

--- a/force.go
+++ b/force.go
@@ -30,6 +30,7 @@ var (
 	ErrFailure = errors.New("general failure")
 	// ErrAuthentication is returned when authentication failed.
 	ErrAuthentication = errors.New("authentication failure")
+	ErrInvalidLogin = errors.New("")
 )
 
 // Client is the main instance to access salesforce.
@@ -95,7 +96,7 @@ func (client *Client) Query(q string) (*QueryResult, error) {
 
 	data, err := client.httpRequest("GET", u, nil)
 	if err != nil {
-		log.Println("HTTP GET request failed:", u)
+		log.Println(logPrefix, "HTTP GET request failed:", u)
 		return nil, err
 	}
 
@@ -212,7 +213,7 @@ func (client *Client) LoginPassword(username, password, token string) error {
 	client.user.email = loginResponse.UserEmail
 	client.user.fullName = loginResponse.UserFullName
 
-	log.Println("User", client.user.name, "authenticated.")
+	log.Println(logPrefix, "User", client.user.name, "authenticated.")
 	return nil
 }
 

--- a/force.go
+++ b/force.go
@@ -174,7 +174,10 @@ func (client *Client) LoginPassword(username, password, token string) error {
 
 	if resp.StatusCode != http.StatusOK {
 		log.Println(logPrefix, "request failed,", resp.StatusCode)
-                log.Println(logPrefix, "failed resp.body: ", resp.Body)
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(resp.Body)
+		newStr := buf.String()
+		log.Println(logPrefix, "Failed resp.body: ", newStr)
 		return ErrFailure
 	}
 
@@ -229,8 +232,11 @@ func (client *Client) httpRequest(method, url string, body io.Reader) ([]byte, e
 	defer resp.Body.Close()
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		log.Println(logPrefix, "status:", resp.StatusCode)
-		log.Println(string(ioutil.ReadAll(resp.Body)))
+		log.Println(logPrefix, "request failed,", resp.StatusCode)
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(resp.Body)
+		newStr := buf.String()
+		log.Println(logPrefix, "Failed resp.body: ", newStr)
 		return nil, ErrFailure
 	}
 

--- a/force.go
+++ b/force.go
@@ -58,15 +58,14 @@ type QueryResult struct {
 
 // Expose sid to save in admin settings
 func (client *Client) GetSid() (sid string) {
-	return Client.sessionId
+        return client.sessionID
 }
 
 // Set SID and Loc as a means to log in without LoginPassword
 func (client *Client) SetSidLoc(sid string, loc string) {
-	client.sessionId = sid
-	client.instanceURL = loc
+        client.sessionID = sid
+        client.instanceURL = loc
 }
-
 
 // Query runs an SOQL query. q could either be the SOQL string or the nextRecordsURL.
 func (client *Client) Query(q string) (*QueryResult, error) {

--- a/force.go
+++ b/force.go
@@ -56,6 +56,18 @@ type QueryResult struct {
 	Records        []SObject `json:"records"`
 }
 
+// Expose sid to save in admin settings
+func (client *Client) GetSid() (sid string) {
+	return Client.sessionId
+}
+
+// Set SID and Loc as a means to log in without LoginPassword
+func (client *Client) SetSidLoc(sid string, loc string) {
+	client.sessionId = sid
+	client.instanceURL = loc
+}
+
+
 // Query runs an SOQL query. q could either be the SOQL string or the nextRecordsURL.
 func (client *Client) Query(q string) (*QueryResult, error) {
 	if !client.isLoggedIn() {

--- a/force.go
+++ b/force.go
@@ -111,6 +111,11 @@ func (client *Client) isLoggedIn() bool {
 	return client.sessionID != ""
 }
 
+func (client *Client) LoginSidLoc(sid string, loc string) {
+        client.sessionID = sid
+        client.instanceURL = loc
+}
+
 // LoginPassword signs into salesforce using password. token is optional if trusted IP is configured.
 // Ref: https://developer.salesforce.com/docs/atlas.en-us.214.0.api_rest.meta/api_rest/intro_understanding_username_password_oauth_flow.htm
 // Ref: https://developer.salesforce.com/docs/atlas.en-us.214.0.api.meta/api/sforce_api_calls_login.htm

--- a/force.go
+++ b/force.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"bytes"
 
 	"github.com/pkg/errors"
 )

--- a/force.go
+++ b/force.go
@@ -61,6 +61,11 @@ func (client *Client) GetSid() (sid string) {
         return client.sessionID
 }
 
+//Expose Loc to save in admin settings
+func (client *Client) GetLoc() (loc string) {
+	return client.instanceURL
+}
+
 // Set SID and Loc as a means to log in without LoginPassword
 func (client *Client) SetSidLoc(sid string, loc string) {
         client.sessionID = sid

--- a/force.go
+++ b/force.go
@@ -112,8 +112,8 @@ func (client *Client) isLoggedIn() bool {
 }
 
 func (client *Client) LoginSidLoc(sid string, loc string) {
-        client.sessionID = sid
-        client.instanceURL = loc
+	client.sessionID = sid
+	client.instanceURL = loc
 }
 
 // LoginPassword signs into salesforce using password. token is optional if trusted IP is configured.
@@ -218,6 +218,7 @@ func (client *Client) httpRequest(method, url string, body io.Reader) ([]byte, e
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		log.Println(logPrefix, "status:", resp.StatusCode)
+		log.Println(ioutil.ReadAll(resp.Body))
 		return nil, ErrFailure
 	}
 

--- a/force.go
+++ b/force.go
@@ -163,6 +163,7 @@ func (client *Client) LoginPassword(username, password, token string) error {
 
 	if resp.StatusCode != http.StatusOK {
 		log.Println(logPrefix, "request failed,", resp.StatusCode)
+                log.Println(logPrefix, "failed resp.body: ", resp.Body)
 		return ErrFailure
 	}
 

--- a/tooling.go
+++ b/tooling.go
@@ -24,6 +24,10 @@ func (client *Client) Tooling() *Client {
 	return client
 }
 
+func (client *Client) UnTooling() {
+	client.useToolingAPI = false
+}
+
 // ExecuteAnonymous executes a body of Apex code
 func (client *Client) ExecuteAnonymous(apexBody string) (*ExecuteAnonymousResult, error) {
 	if !client.isLoggedIn() {

--- a/tooling.go
+++ b/tooling.go
@@ -41,7 +41,7 @@ func (client *Client) ExecuteAnonymous(apexBody string) (*ExecuteAnonymousResult
 
 	data, err := client.httpRequest("GET", endpoint, nil)
 	if err != nil {
-		log.Println("HTTP GET request failed:", endpoint)
+		log.Println(logPrefix, "HTTP GET request failed:", endpoint)
 		return nil, err
 	}
 


### PR DESCRIPTION
Added logging before returning "General Failure".  General Failure is as unexpressive as it comes. When the library fails, why is it failing?  malformed query? Invalid Login credentials?  Something else?   These changes at least log the error message so there is some semblance of a paper trail.  

(Besides what about the other members of the failed army?  Lieutenant Busted, Corporal Punished and Major Fuckup nowhere to be seen).

Added SID/Loc support to avoid locking out users with invalid credentials.  




