### PR TITLE
Add salesforce api response body on err

### DIFF
--- a/force.go
+++ b/force.go
@@ -213,6 +213,13 @@ func (client *Client) httpRequest(method, url string, body io.Reader) ([]byte, e
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		log.Println(logPrefix, "status:", resp.StatusCode)
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+
+		if err != nil {
+			return nil, err
+		}
+
+		log.Printf("%s response: %s\n", logPrefix, bodyBytes)
 		return nil, ErrFailure
 	}
 


### PR DESCRIPTION
It is handy to know the response of the salesforce api on error.