### PR TITLE
Fix trailing slash issue with base URL

### DIFF
--- a/force.go
+++ b/force.go
@@ -235,9 +235,9 @@ func NewClient(url, clientID, apiVersion string) *Client {
 		httpClient: &http.Client{},
 	}
 
-	// Append "/" to the end of baseURL if not yet.
-	if !strings.HasSuffix(client.baseURL, "/") {
-		client.baseURL = client.baseURL + "/"
+	// Remove trailing "/" from base url to prevent "//" when paths are appended
+	if strings.HasSuffix(client.baseURL, "/") {
+		client.baseURL = client.baseURL[:len(client.baseURL)-1]
 	}
 	return client
 }


### PR DESCRIPTION
The trailing slash for base URL is currently resulting in urls like `https://salesforce.com//api/resource`. This could potentially cause issues depending on the server implementation handling the request.