### PR TITLE
Preserve details when parsing Salesforce errors

### DIFF
--- a/errorHelpers.go
+++ b/errorHelpers.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"github.com/pkg/errors"
 	"log"
+
+	"github.com/pkg/errors"
 )
 
 var (
@@ -22,31 +23,24 @@ type jsonError []struct {
 }
 
 type xmlError struct {
-	Message string `xml:"Body>Fault>faultstring"`
+	Message   string `xml:"Body>Fault>faultstring"`
 	ErrorCode string `xml:"Body>Fault>faultcode"`
 }
 
 //Need to get information out of this package.
 func ParseSalesforceError(statusCode int, responseBody []byte) (err error) {
 	jsonError := jsonError{}
-	xmlError := xmlError{}
 	err = json.Unmarshal(responseBody, &jsonError)
-	if err != nil {
-		//Unable to parse json. Try xml
-		err = xml.Unmarshal(responseBody, &xmlError)
-		if err != nil {
-			//Unable to parse json or XML
-			log.Println("ERROR UNMARSHALLING: ", err)
-			return ErrFailure
-		}
-		//successfully parsed XML:
-		message := fmt.Sprintf(logPrefix+" Error. http code: %v Error Message:  %v Error Code: %v", statusCode, xmlError.Message, xmlError.ErrorCode)
-		err = errors.New(message)
-		return err
-	} else {
-		//Successfully parsed json error:
-		message := fmt.Sprintf(logPrefix+" Error. http code: %v Error Message:  %v Error Code: %v", statusCode, jsonError[0].Message, jsonError[0].ErrorCode)
-		err = errors.New(message)
-		return err
+	if err == nil {
+		return fmt.Errorf(logPrefix+" Error. http code: %v Error Message:  %v Error Code: %v", statusCode, jsonError[0].Message, jsonError[0].ErrorCode)
 	}
+
+	xmlError := xmlError{}
+	err = xml.Unmarshal(responseBody, &xmlError)
+	if err == nil {
+		return fmt.Errorf(logPrefix+" Error. http code: %v Error Message:  %v Error Code: %v", statusCode, xmlError.Message, xmlError.ErrorCode)
+	}
+
+	log.Println("ERROR UNMARSHALLING: ", err)
+	return ErrFailure
 }

--- a/errorHelpers_test.go
+++ b/errorHelpers_test.go
@@ -1,0 +1,56 @@
+package simpleforce
+
+import (
+	"testing"
+)
+
+var expectedError SalesforceError = SalesforceError{
+	HttpCode:     417,
+	Message:      logPrefix + " Error. http code: 417 Error Message:  something went wrong Error Code: SMTH_WRNG",
+	ErrorCode:    "SMTH_WRNG",
+	ErrorMessage: "something went wrong",
+}
+
+func TestSuccessfulJSONParse(t *testing.T) {
+	response := `[
+		{
+			"message": "something went wrong",
+			"errorCode": "SMTH_WRNG"
+		}
+	]`
+
+	err := ParseSalesforceError(417, []byte(response))
+	if err != expectedError {
+		t.Errorf("failed to parse JSON error, got %s", err)
+	}
+}
+
+func TestSuccessfulXMLParse(t *testing.T) {
+	response := `
+		<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+			<s:Body>
+				<s:Fault>
+					<faultcode>SMTH_WRNG</faultcode>
+					<faultstring xml:lang="en-US">something went wrong</faultstring>
+				</s:Fault>
+			</s:Body>
+		</s:Envelope>
+	`
+	err := ParseSalesforceError(417, []byte(response))
+	if err != expectedError {
+		t.Errorf("failed to parse XML error, got %s", err)
+	}
+}
+
+func TestUnsuccessfulParse(t *testing.T) {
+	response := "surprise!"
+	unknownError := SalesforceError{
+		HttpCode: 417,
+		Message:  "surprise!",
+	}
+
+	err := ParseSalesforceError(417, []byte(response))
+	if err != unknownError {
+		t.Errorf("failed to parse unknown error, got %s", err)
+	}
+}


### PR DESCRIPTION
Currently `ParseSalesforceError` function extracts ErrorCode and ErrorMessage from Salesforce's JSON or XML response. But those are just written into the error message, making using them upstream inconvenient. 

This MR introduces error type `SalesforceError`, which returns the same `.Error()` string message, but also provides fields for http code, salesforce error code, and salesforce error message.

Also it improves handling of unparsed error messages, giving upstream clients information about http code and exact error message.