### PR TITLE
Query should be escaped by QueryEscape, not PathEscape

### DIFF
--- a/force.go
+++ b/force.go
@@ -50,7 +50,7 @@ type QueryResult struct {
 
 // Expose sid to save in admin settings
 func (client *Client) GetSid() (sid string) {
-	return client.sessionID
+        return client.sessionID
 }
 
 //Expose Loc to save in admin settings
@@ -60,8 +60,8 @@ func (client *Client) GetLoc() (loc string) {
 
 // Set SID and Loc as a means to log in without LoginPassword
 func (client *Client) SetSidLoc(sid string, loc string) {
-	client.sessionID = sid
-	client.instanceURL = loc
+        client.sessionID = sid
+        client.instanceURL = loc
 }
 
 // Query runs an SOQL query. q could either be the SOQL string or the nextRecordsURL.
@@ -283,31 +283,19 @@ func (client *Client) SetHttpClient(c *http.Client) {
 
 // DownloadFile downloads a file based on the REST API path given. Saves to filePath.
 func (client *Client) DownloadFile(contentVersionID string, filepath string) error {
-	apiPath := fmt.Sprintf(
-		"/services/data/v%s/sobjects/ContentVersion/%s/VersionData",
-		client.apiVersion,
-		contentVersionID,
-	)
+	apiPath := fmt.Sprintf("/services/data/v%s/sobjects/ContentVersion/%s/VersionData", client.apiVersion, contentVersionID)
 	return client.download(apiPath, filepath)
 }
 
 func (client *Client) DownloadAttachment(attachmentId string, filepath string) error {
-	apiPath := fmt.Sprintf(
-		"/services/data/v%s/sobjects/Attachment/%s/Body",
-		client.apiVersion,
-		attachmentId,
-	)
+	apiPath := fmt.Sprintf("/services/data/v%s/sobjects/Attachment/%s/Body", client.apiVersion, attachmentId)
 	return client.download(apiPath, filepath)
 }
 
 func (client *Client) download(apiPath string, filepath string) error {
 	// Get the data
 	httpClient := client.httpClient
-	req, err := http.NewRequest(
-		"GET",
-		fmt.Sprintf("%s%s", strings.TrimRight(client.instanceURL, "/"), apiPath),
-		nil,
-	)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s%s", strings.TrimRight(client.instanceURL, "/"), apiPath), nil)
 	req.Header.Add("Content-Type", "application/json; charset=UTF-8")
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Authorization", "Bearer "+client.sessionID)

--- a/force.go
+++ b/force.go
@@ -50,7 +50,7 @@ type QueryResult struct {
 
 // Expose sid to save in admin settings
 func (client *Client) GetSid() (sid string) {
-        return client.sessionID
+	return client.sessionID
 }
 
 //Expose Loc to save in admin settings
@@ -60,8 +60,8 @@ func (client *Client) GetLoc() (loc string) {
 
 // Set SID and Loc as a means to log in without LoginPassword
 func (client *Client) SetSidLoc(sid string, loc string) {
-        client.sessionID = sid
-        client.instanceURL = loc
+	client.sessionID = sid
+	client.instanceURL = loc
 }
 
 // Query runs an SOQL query. q could either be the SOQL string or the nextRecordsURL.
@@ -81,7 +81,7 @@ func (client *Client) Query(q string) (*QueryResult, error) {
 		if client.useToolingAPI {
 			formatString = strings.Replace(formatString, "query", "tooling/query", -1)
 		}
-		u = fmt.Sprintf(formatString, baseURL, client.apiVersion, url.PathEscape(q))
+		u = fmt.Sprintf(formatString, baseURL, client.apiVersion, url.QueryEscape(q))
 	}
 
 	data, err := client.httpRequest("GET", u, nil)
@@ -283,19 +283,31 @@ func (client *Client) SetHttpClient(c *http.Client) {
 
 // DownloadFile downloads a file based on the REST API path given. Saves to filePath.
 func (client *Client) DownloadFile(contentVersionID string, filepath string) error {
-	apiPath := fmt.Sprintf("/services/data/v%s/sobjects/ContentVersion/%s/VersionData", client.apiVersion, contentVersionID)
+	apiPath := fmt.Sprintf(
+		"/services/data/v%s/sobjects/ContentVersion/%s/VersionData",
+		client.apiVersion,
+		contentVersionID,
+	)
 	return client.download(apiPath, filepath)
 }
 
 func (client *Client) DownloadAttachment(attachmentId string, filepath string) error {
-	apiPath := fmt.Sprintf("/services/data/v%s/sobjects/Attachment/%s/Body", client.apiVersion, attachmentId)
+	apiPath := fmt.Sprintf(
+		"/services/data/v%s/sobjects/Attachment/%s/Body",
+		client.apiVersion,
+		attachmentId,
+	)
 	return client.download(apiPath, filepath)
 }
 
 func (client *Client) download(apiPath string, filepath string) error {
 	// Get the data
 	httpClient := client.httpClient
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s%s", strings.TrimRight(client.instanceURL, "/"), apiPath), nil)
+	req, err := http.NewRequest(
+		"GET",
+		fmt.Sprintf("%s%s", strings.TrimRight(client.instanceURL, "/"), apiPath),
+		nil,
+	)
 	req.Header.Add("Content-Type", "application/json; charset=UTF-8")
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Authorization", "Bearer "+client.sessionID)

--- a/force_test.go
+++ b/force_test.go
@@ -125,6 +125,28 @@ func TestClient_Query2(t *testing.T) {
 	}
 }
 
+func TestClient_Query3(t *testing.T) {
+	client := requireClient(t, true)
+
+	q := "SELECT Id FROM CaseComment WHERE CommentBody = 'This comment is created by simpleforce & used for testing'"
+	result, err := client.Query(q)
+	if err != nil {
+		log.Println(logPrefix, "query failed,", err)
+		t.FailNow()
+	}
+
+	log.Println(logPrefix, result.TotalSize, result.Done, result.NextRecordsURL)
+	if result.TotalSize < 1 {
+		log.Println(logPrefix, "no records returned.")
+		t.FailNow()
+	}
+	for _, record := range result.Records {
+		if record.Type() != "CaseComment" {
+			t.Fail()
+		}
+	}
+}
+
 func TestClient_ApexREST(t *testing.T) {
 	client := requireClient(t, true)
 

--- a/sobject_test.go
+++ b/sobject_test.go
@@ -150,7 +150,7 @@ func TestSObject_Create(t *testing.T) {
 	// Positive 2
 	caseComment1 := client.SObject("CaseComment")
 	caseComment1Result := caseComment1.Set("ParentId", case1Result.ID()).
-		Set("CommentBody", "This comment is created by simpleforce").
+		Set("CommentBody", "This comment is created by simpleforce & used for testing").
 		Set("IsPublished", true).
 		Create()
 	if caseComment1Result.Get().SObjectField("Case", "ParentId").ID() != case1Result.ID() {


### PR DESCRIPTION
Given an SOQL query like this:
`SELECT Id FROM Account WHERE Name = 'Ace \& Tate'`

Currently, if an ampersand is included in an SOQL query, it results in a request like this:
`https://company.my.salesforce.com/services/data/v53.0/query?q=SELECT+Id+FROM+Opportunity+WHERE+Name+%3D+%27Ace+%5C&+Tate%27`
The ampersand is unescaped.

However, it should result in a properly escaped version so that the ampersand does not trigger a new URL param:
`https://company.my.salesforce.com/services/data/v53.0/query?q=SELECT+Id+FROM+Opportunity+WHERE+Name+%3D+%27Ace+%5C%26+Tate%27`